### PR TITLE
feat: add sound-cloud button

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hh-slate-editor",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "description": "Slate Editor customized by Hahow",
   "author": "barry800414",
   "license": "MIT",

--- a/src/SlateEditor.component.js
+++ b/src/SlateEditor.component.js
@@ -450,6 +450,14 @@ class SlateEditor extends React.Component {
     });
   }
 
+  onClickSoundCloud = (event) => {
+    event.preventDefault();
+    this.setState({
+      currentOpenDialog: 'soundcloud',
+      dialogValue: '',
+    });
+  }
+
   onInsertTab = (event) => {
     event.preventDefault();
     this.editor.insertText('    ');
@@ -583,6 +591,16 @@ class SlateEditor extends React.Component {
 
     if (url && mixcloudRegExp.test(url)) {
       const src = `https://www.mixcloud.com/widget/iframe/?hide_cover=1&light=1&hide_artwork=1&feed=${encodeURIComponent(url)}`;
+      const hasListItem = this.hasBlock('list-item');
+      this.editor.command(addIframe, 'audio', src, hasListItem);
+    }
+  }
+
+  insertSoundCloud = (url) => {
+    const soundCloudRegExp = /(https:)?\/\/soundcloud\.com\/.*\/.*/;
+
+    if (url && soundCloudRegExp.test(url)) {
+      const src = `https://w.soundcloud.com/player/?url=${encodeURIComponent(url)}&color=%23ff5500&auto_play=false&hide_related=true&show_comments=false&show_user=false&show_reposts=false&show_teaser=false`;
       const hasListItem = this.hasBlock('list-item');
       this.editor.command(addIframe, 'audio', src, hasListItem);
     }
@@ -922,6 +940,7 @@ class SlateEditor extends React.Component {
           {this.renderButton(this.onClickYoutube, <FontAwesome name="youtube-play" />, 'Youtube', 'youtube-button')}
           {this.renderButton(this.onClickVimeo, <FontAwesome name="vimeo-square" />, 'Vimeo', 'vimeo-button')}
           {this.renderButton(this.onClickMixCloud, <FontAwesome name="mixcloud" />, 'Mixcloud', 'mixcloud-button')}
+          {this.renderButton(this.onClickSoundCloud, <FontAwesome name="soundcloud" />, 'Soundcloud', 'soundcloud-button')}
         </div>
       </div>
       {this.renderFullScreenButton()}
@@ -1022,6 +1041,22 @@ class SlateEditor extends React.Component {
             onClose={onClose}
             onSubmit={() => {
               this.insertMixCloud(this.state.dialogValue);
+              onClose();
+            }}
+          />
+        );
+      case 'soundcloud':
+        return (
+          <InputDialog
+            title="請輸入 SoundCloud 網址"
+            text="範例：https://www.soundcloud.com/ooo/xxx"
+            value={this.state.dialogValue}
+            isOpen
+            validate={editorJoiSchema.soundCloudUrl}
+            onChange={onChange}
+            onClose={onClose}
+            onSubmit={() => {
+              this.insertSoundCloud(this.state.dialogValue);
               onClose();
             }}
           />

--- a/src/SlateEditor.component.js
+++ b/src/SlateEditor.component.js
@@ -600,7 +600,7 @@ class SlateEditor extends React.Component {
     const soundCloudRegExp = /(https:)?\/\/soundcloud\.com\/.*\/.*/;
 
     if (url && soundCloudRegExp.test(url)) {
-      const src = `https://w.soundcloud.com/player/?url=${encodeURIComponent(url)}&color=%23ff5500&auto_play=false&hide_related=true&show_comments=false&show_user=false&show_reposts=false&show_teaser=false`;
+      const src = `https://w.soundcloud.com/player/?color=%23ff5500&auto_play=false&hide_related=true&show_comments=false&show_user=false&show_reposts=false&show_teaser=false&url=${encodeURIComponent(url)}`;
       const hasListItem = this.hasBlock('list-item');
       this.editor.command(addIframe, 'audio', src, hasListItem);
     }

--- a/src/SlateEditor.component.js
+++ b/src/SlateEditor.component.js
@@ -1049,7 +1049,7 @@ class SlateEditor extends React.Component {
         return (
           <InputDialog
             title="請輸入 SoundCloud 網址"
-            text="範例：https://www.soundcloud.com/ooo/xxx"
+            text="範例：https://soundcloud.com/ooo/xxx"
             value={this.state.dialogValue}
             isOpen
             validate={editorJoiSchema.soundCloudUrl}

--- a/src/SlateEditor.style.js
+++ b/src/SlateEditor.style.js
@@ -31,7 +31,7 @@ const StyledSlateEditor = StyledRichTextView.extend`
   }
 
   .toolbar-menu {
-    padding: 5px 24px 0;
+    padding: 5px 10px 0;
     margin: 0;
     background-color: #f5f5f5;
     border-color: #ddd;
@@ -74,11 +74,14 @@ const StyledSlateEditor = StyledRichTextView.extend`
     .button-group + .button-group {
       margin-right: 12px;
     }
+    .button-group:last-of-type {
+      margin-right: 45px;
+    }
   }
 
   .toolbar-menu .full-screen-btn {
     position: absolute;
-    right: 24px;
+    right: 10px;
     top: 5px;
   }
 

--- a/src/components/Iframe.component.js
+++ b/src/components/Iframe.component.js
@@ -52,7 +52,7 @@ class Iframe extends React.Component {
     } else if (type === 'audio') {
       return (
         <iframe
-          title="video"
+          title="audio"
           type="text/html"
           src={src}
           frameBorder="0"

--- a/src/utils/slateHtmlSerializer.js
+++ b/src/utils/slateHtmlSerializer.js
@@ -28,9 +28,10 @@ const getIframeType = (src) => {
   const youtubePrefix = '//www.youtube.com/embed/';
   const vimeoPrefix = '//player.vimeo.com/video/';
   const mixCloudPrefix = 'https://www.mixcloud.com/widget/iframe/';
+  const soundCloudPrefix = 'https://w.soundcloud.com/player/';
   if (src.indexOf(youtubePrefix) >= 0 || src.indexOf(vimeoPrefix) >= 0) {
     return 'video';
-  } else if (src.indexOf(mixCloudPrefix) === 0) {
+  } else if (src.indexOf(mixCloudPrefix) === 0 || src.indexOf(soundCloudPrefix) === 0) {
     return 'audio';
   }
   // eslint-disable-next-line no-console

--- a/src/utils/validator.js
+++ b/src/utils/validator.js
@@ -49,5 +49,14 @@ export const editorJoiSchema = {
       }
     }
     return false;
+  },
+  soundCloudUrl: (input) => {
+    if (input && typeof input === 'string') {
+      const regex = /(https:)?\/\/soundcloud\.com\/.*\/.*/;
+      if (regex.test(input)) {
+        return true;
+      }
+    }
+    return false;
   }
 };


### PR DESCRIPTION
## 這個 PR 做了什麼？

新增插入 SoundCloud 的功能
![l2G3kZ8E3v](https://user-images.githubusercontent.com/3805975/60854750-ec1f0b00-a233-11e9-8d57-af4b6a2debf1.gif)


## 如何測試？
- [ ] yarn run build; cd example; yarn start
- [ ] 按 SoundCloud 按鈕，輸入 https://soundcloud.com/ooo/xxx 像這樣的網址，應該要能正常插入 soundcloud iframe
- [ ] 調整螢幕寬度，按鈕之間不應該重疊到

## 注意事項
- [ ] 目前 hh-frontend-react 的部分，因為不是用 hh-slate-editor。所以 hh-frontend-react 裡面的編輯器，也要做相對應的修改 https://github.com/hahow/hh-frontend-react/pull/3270
