### PR TITLE
Feat/insert content from outside

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -3,11 +3,27 @@ import React, { Component } from 'react'
 import SlateEditor from 'hh-slate-editor'
 
 export default class App extends Component {
+  constructor(props) {
+    super(props);
+    this.editorRef = React.createRef();
+  }
+
+  insertFragment = () => {
+    if (this.editorRef && this.editorRef.current) {
+      this.editorRef.current.insertFragment('<h4>開課緣起</h4><p>簡述開課動機或老師對此堂課的目標與期許</p>');
+    }
+  }
+
   render () {
     return (
-      <div>
+      <div style={{ padding: 20 }}>
         <h1>Slate Editor Demo</h1>
-        <SlateEditor text='Modern React component module' />
+        <div style={{ marginBottom: 10 }}>
+          <button onClick={this.insertFragment}>插入段落</button>
+        </div>
+        <SlateEditor
+          ref={this.editorRef}
+        />
       </div>
     )
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hh-slate-editor",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Slate Editor customized by Hahow",
   "author": "barry800414",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hh-slate-editor",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "description": "Slate Editor customized by Hahow",
   "author": "barry800414",
   "license": "MIT",

--- a/src/SlateEditor.component.js
+++ b/src/SlateEditor.component.js
@@ -450,6 +450,14 @@ class SlateEditor extends React.Component {
     });
   }
 
+  onClickSoundCloud = (event) => {
+    event.preventDefault();
+    this.setState({
+      currentOpenDialog: 'soundcloud',
+      dialogValue: '',
+    });
+  }
+
   onInsertTab = (event) => {
     event.preventDefault();
     this.editor.insertText('    ');
@@ -583,6 +591,16 @@ class SlateEditor extends React.Component {
 
     if (url && mixcloudRegExp.test(url)) {
       const src = `https://www.mixcloud.com/widget/iframe/?hide_cover=1&light=1&hide_artwork=1&feed=${encodeURIComponent(url)}`;
+      const hasListItem = this.hasBlock('list-item');
+      this.editor.command(addIframe, 'audio', src, hasListItem);
+    }
+  }
+
+  insertSoundCloud = (url) => {
+    const soundCloudRegExp = /(https:)?\/\/soundcloud\.com\/.*\/.*/;
+
+    if (url && soundCloudRegExp.test(url)) {
+      const src = `https://w.soundcloud.com/player/?url=${encodeURIComponent(url)}&color=%23ff5500&auto_play=false&hide_related=true&show_comments=false&show_user=false&show_reposts=false&show_teaser=false`;
       const hasListItem = this.hasBlock('list-item');
       this.editor.command(addIframe, 'audio', src, hasListItem);
     }
@@ -922,6 +940,7 @@ class SlateEditor extends React.Component {
           {this.renderButton(this.onClickYoutube, <FontAwesome name="youtube-play" />, 'Youtube', 'youtube-button')}
           {this.renderButton(this.onClickVimeo, <FontAwesome name="vimeo-square" />, 'Vimeo', 'vimeo-button')}
           {this.renderButton(this.onClickMixCloud, <FontAwesome name="mixcloud" />, 'Mixcloud', 'mixcloud-button')}
+          {this.renderButton(this.onClickSoundCloud, <FontAwesome name="soundcloud" />, 'Soundcloud', 'soundcloud-button')}
         </div>
       </div>
       {this.renderFullScreenButton()}
@@ -1022,6 +1041,22 @@ class SlateEditor extends React.Component {
             onClose={onClose}
             onSubmit={() => {
               this.insertMixCloud(this.state.dialogValue);
+              onClose();
+            }}
+          />
+        );
+      case 'soundcloud':
+        return (
+          <InputDialog
+            title="請輸入 SoundCloud 網址"
+            text="範例：https://www.soundcloud.com/ooo/xxx"
+            value={this.state.dialogValue}
+            isOpen
+            validate={editorJoiSchema.soundCloudUrl}
+            onChange={onChange}
+            onClose={onClose}
+            onSubmit={() => {
+              this.insertSoundCloud(this.state.dialogValue);
               onClose();
             }}
           />

--- a/src/SlateEditor.component.js
+++ b/src/SlateEditor.component.js
@@ -600,7 +600,7 @@ class SlateEditor extends React.Component {
     const soundCloudRegExp = /(https:)?\/\/soundcloud\.com\/.*\/.*/;
 
     if (url && soundCloudRegExp.test(url)) {
-      const src = `https://w.soundcloud.com/player/?url=${encodeURIComponent(url)}&color=%23ff5500&auto_play=false&hide_related=true&show_comments=false&show_user=false&show_reposts=false&show_teaser=false`;
+      const src = `https://w.soundcloud.com/player/?color=%23ff5500&auto_play=false&hide_related=true&show_comments=false&show_user=false&show_reposts=false&show_teaser=false&url=${encodeURIComponent(url)}`;
       const hasListItem = this.hasBlock('list-item');
       this.editor.command(addIframe, 'audio', src, hasListItem);
     }

--- a/src/SlateEditor.component.js
+++ b/src/SlateEditor.component.js
@@ -621,6 +621,16 @@ class SlateEditor extends React.Component {
     }
   }
 
+  /**
+   * 這個 function 主要用於從 editor 外部插入內容使用
+   *
+   * @param {string} html html string to be inserted
+   */
+  insertFragment = (html) => {
+    const { document } = htmlSerializer.deserialize(html);
+    this.editor.insertFragment(document);
+  }
+
   editLink = (nodeKey, href, openInNewWindow) => {
     this.editor.command(setLinkByKey, nodeKey, href, openInNewWindow);
   }

--- a/src/SlateEditor.style.js
+++ b/src/SlateEditor.style.js
@@ -31,7 +31,7 @@ const StyledSlateEditor = StyledRichTextView.extend`
   }
 
   .toolbar-menu {
-    padding: 5px 24px 0;
+    padding: 5px 10px 0;
     margin: 0;
     background-color: #f5f5f5;
     border-color: #ddd;
@@ -74,11 +74,14 @@ const StyledSlateEditor = StyledRichTextView.extend`
     .button-group + .button-group {
       margin-right: 12px;
     }
+    .button-group:last-of-type {
+      margin-right: 45px;
+    }
   }
 
   .toolbar-menu .full-screen-btn {
     position: absolute;
-    right: 24px;
+    right: 10px;
     top: 5px;
   }
 

--- a/src/components/Iframe.component.js
+++ b/src/components/Iframe.component.js
@@ -52,7 +52,7 @@ class Iframe extends React.Component {
     } else if (type === 'audio') {
       return (
         <iframe
-          title="video"
+          title="audio"
           type="text/html"
           src={src}
           frameBorder="0"

--- a/src/utils/slateHtmlSerializer.js
+++ b/src/utils/slateHtmlSerializer.js
@@ -28,9 +28,10 @@ const getIframeType = (src) => {
   const youtubePrefix = '//www.youtube.com/embed/';
   const vimeoPrefix = '//player.vimeo.com/video/';
   const mixCloudPrefix = 'https://www.mixcloud.com/widget/iframe/';
+  const soundCloudPrefix = 'https://w.soundcloud.com/player/';
   if (src.indexOf(youtubePrefix) >= 0 || src.indexOf(vimeoPrefix) >= 0) {
     return 'video';
-  } else if (src.indexOf(mixCloudPrefix) === 0) {
+  } else if (src.indexOf(mixCloudPrefix) === 0 || src.indexOf(soundCloudPrefix) === 0) {
     return 'audio';
   }
   // eslint-disable-next-line no-console

--- a/src/utils/validator.js
+++ b/src/utils/validator.js
@@ -49,5 +49,14 @@ export const editorJoiSchema = {
       }
     }
     return false;
+  },
+  soundCloudUrl: (input) => {
+    if (input && typeof input === 'string') {
+      const regex = /(https:)?\/\/soundcloud\.com\/.*\/.*/;
+      if (regex.test(input)) {
+        return true;
+      }
+    }
+    return false;
   }
 };


### PR DESCRIPTION
## 這個 PR 做了什麼？

讓 SlateEditor 這個 component 提供一個外部的 API ，可以直接插內容段落進去。

base on #6 ，看 fab7dda 這個 commit 即可

## 如何測試？
- [ ] yarn run build
- [ ] cd example; yarn run start
- [ ] 先不 focus ，按插入段落，要可以正常插入段落
- [ ] focus 後，按插入段落，要原本 focus 的地方插入段落
- [ ] cmd + z 可以復原